### PR TITLE
Fix small `rubocop:todo` typo.

### DIFF
--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -569,8 +569,9 @@ You can also disable *all* cops with
 # rubocop:enable all
 ```
 
-In cases where you want to differentiate intentional disabled vs disables that
-you'd like to revisit later, you can use disable:todo as an alias of rubocop:disable.
+In cases where you want to differentiate intentionally-disabled cops vs. cops
+you'd like to revisit later, you can use `rubocop:todo` as an alias of
+`rubocop:disable`.
 
 ```ruby
 # rubocop:todo Layout/LineLength, Style/StringLiterals


### PR DESCRIPTION
The documentation looks incorrect regarding the the `todo` escape hatch. This change fixes that issue.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
